### PR TITLE
Run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,22 @@
 FROM eclipse-temurin:11-jre-alpine
+ARG UID=100
+ARG GID=101
 
 ENV JMB_VERSION 0.4.1
 
+# Create a group and user
+RUN addgroup -S appgroup -g ${GID} && adduser -S appuser -G appgroup -u ${UID}
+
 #No downloadable example config since 0.2.10
-RUN mkdir -p /jmb/config
-ADD https://github.com/jagrosh/MusicBot/releases/download/$JMB_VERSION/JMusicBot-$JMB_VERSION.jar /jmb/JMusicBot.jar
-ADD https://github.com/jagrosh/MusicBot/releases/download/0.2.9/config.txt /jmb/config/config.txt
+RUN mkdir -p /jmb/config && \
+    chown -R appuser:appgroup /jmb
 
-COPY ./docker-entrypoint.sh /jmb
+USER appuser
 
-RUN chmod +x /jmb/docker-entrypoint.sh
+ADD --chown=appuser:appgroup https://github.com/jagrosh/MusicBot/releases/download/$JMB_VERSION/JMusicBot-$JMB_VERSION.jar /jmb/JMusicBot.jar
+ADD --chown=appuser:appgroup https://github.com/jagrosh/MusicBot/releases/download/0.2.9/config.txt /jmb/config/config.txt
+
+COPY --chmod=755 ./docker-entrypoint.sh /jmb
 
 VOLUME /jmb/config
 


### PR DESCRIPTION
This PR improves container security by running the application as a non-root user.
Following the discussion in https://github.com/craumix/jmb-container/pull/11#issuecomment-2212550525, I moved out the changes to implement a non-root user in the container due to UID/GID issues with the config file.

Now the Dockerfile accepts the UID/GID as an argument.

Some questions:
* [ ] Should these default to less common IDs?
* [ ] Should the entrypoint be modified to start as root, ensure the correct permissions on `/config`, and then `su` to the appuser? Or should instructions be provided to run `chown` on the host?